### PR TITLE
fix: skip dependency version alignment when host DSH version is unpublished

### DIFF
--- a/bin/dsh-tavern.mjs
+++ b/bin/dsh-tavern.mjs
@@ -316,14 +316,33 @@ function prepareProfileConfiguration(host, dshVersion) {
   return { manifest, patchText }
 }
 
+function dshDependencyVersionExists(packageName, version) {
+  const result = spawnSync(commandName('pnpm'), ['view', `${packageName}@${version}`, 'version'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  })
+  if (result.error || result.status !== 0) return false
+  return result.stdout.trim() === version
+}
+
 function installPluginDependencies(dshVersion) {
   const pluginDirectory = path.join(SOURCE_ROOT, 'tavern-plugin')
   const workspacePath = path.join(pluginDirectory, 'pnpm-workspace.yaml')
   const original = readFileSync(workspacePath, 'utf8')
   const workspace = parseDocument(original)
   if (workspace.errors.length > 0) throw new Error(`无法读取插件 workspace：${workspace.errors[0].message}`)
-  workspace.setIn(['overrides', '@deepseek-ai/dsh-subagent'], dshVersion)
-  workspace.setIn(['overrides', '@deepseek-ai/dsh-tools'], dshVersion)
+  const subagentAvailable = dshDependencyVersionExists('@deepseek-ai/dsh-subagent', dshVersion)
+  const toolsAvailable = dshDependencyVersionExists('@deepseek-ai/dsh-tools', dshVersion)
+  if (subagentAvailable && toolsAvailable) {
+    workspace.setIn(['overrides', '@deepseek-ai/dsh-subagent'], dshVersion)
+    workspace.setIn(['overrides', '@deepseek-ai/dsh-tools'], dshVersion)
+  } else {
+    const missing = [
+      subagentAvailable ? '' : '@deepseek-ai/dsh-subagent',
+      toolsAvailable ? '' : '@deepseek-ai/dsh-tools',
+    ].filter(Boolean).join('、')
+    console.warn(`npm 上不存在 ${missing}@${dshVersion}，已跳过版本对齐，将按 tavern-plugin 声明的版本范围安装。`)
+  }
   const temporary = `${workspacePath}.tmp-${process.pid}`
   try {
     writeFileSync(temporary, workspace.toString(), 'utf8')

--- a/tests/launcher.test.mjs
+++ b/tests/launcher.test.mjs
@@ -460,6 +460,12 @@ test('Tavern 依赖安装时与当前宿主 DSH 版本对齐', () => {
   assert.match(launcherSource, /install', '--lockfile=false'/)
 })
 
+test('宿主 DSH 版本未发布到 npm 时跳过版本对齐而非失败', () => {
+  assert.match(launcherSource, /dshDependencyVersionExists\(/)
+  assert.match(launcherSource, /subagentAvailable && toolsAvailable/)
+  assert.match(launcherSource, /已跳过版本对齐/)
+})
+
 test('升级后用户数据固定在 Profile 目录，并在安装时迁移旧源码数据', () => {
   assert.match(launcherSource, /resolveTavernDataRoot\(\{ dshHome: DSH_ROOT \}\)/)
   assert.match(launcherSource, /migrateLegacyTavernData\(\{/)


### PR DESCRIPTION
## 问题

DSH Desktop 2.0.4 内置的运行时版本是 `0.1.2-alpha.1`（`dsh --version` 返回该版本，且 Desktop 自带的 `node_modules/@deepseek-ai/dsh-tools` 也是这个版本），但该版本**从未发布到公共 npm**——registry 上 `@deepseek-ai/dsh-tools` 只有 11 个发布版本，最新的是 `0.0.1-rc.1`（latest）、`0.1.1-rc.2`（next），没有 `0.1.2-alpha.1`。

安装脚本 `bin/dsh-tavern.mjs` 的 `installPluginDependencies()` 无条件把 `@deepseek-ai/dsh-tools` 和 `@deepseek-ai/dsh-subagent` 两个依赖 override 成宿主 DSH 版本（即 `0.1.2-alpha.1`），然后以 `--lockfile=false` 全新解析，pnpm 报 `ERR_PNPM_NO_MATCHING_VERSION`，整个 Tavern profile 安装中止（issue #7）。

## 修复

安装前用 `pnpm view <pkg>@<version> version` 探测宿主版本是否已发布到 npm：

- **已发布**：保持原有行为，写 override 与宿主版本对齐；
- **未发布**（如 DSH Desktop 2.0.4 的 `0.1.2-alpha.1`）：跳过版本对齐并输出警告，回退为按 `tavern-plugin/package.json` 声明的范围（`>=0.1.0-rc.7`）解析，安装不再中止。

## 测试

- 新增源码断言测试：`宿主 DSH 版本未发布到 npm 时跳过版本对齐而非失败`；
- `tests/launcher.test.mjs` 与 `tests/dsh-compatibility.test.mjs` 全部通过（45/45）；
- 完整套件结果与改动前基线一致（既有 14 个失败均为 Windows 平台路径断言问题，与本改动无关）。

Fixes #7