### PR TITLE
fix: allow mobile touch scroll over message iframes

### DIFF
--- a/dsh-tavern-runtime.json
+++ b/dsh-tavern-runtime.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "revision": "75234539d7a930613fb3b8d66170f475bcd350d5",
+  "revision": "55f7c609249553236bacefee645c42505ae336c8",
   "files": [
     {
       "path": "bin/dsh-compatibility.mjs",
@@ -19,13 +19,18 @@
     },
     {
       "path": "bin/dsh-tavern.mjs",
-      "sha256": "94c0b31b5f8a749aff1139454b30115ff2ca9c3d3f51111d16e001270b3e2634",
-      "size": 41207
+      "sha256": "2b9f699b50ceaf43309cde8337de97baca26ac3e4680a34cdc9142d11f83da63",
+      "size": 40512
+    },
+    {
+      "path": "bin/plugin-dependencies.mjs",
+      "sha256": "0bfdc43be1a30f32dfc101f6f7d4c728f41e7da13c516498ca9266399f073e08",
+      "size": 5500
     },
     {
       "path": "bin/profile-configuration.mjs",
-      "sha256": "2429a368b1f0bbe796f4b1e5b9697eb42260babcaae6e93e1113f5cc7473eeef",
-      "size": 9807
+      "sha256": "146d4c342810d09398990df249b5e50d750d51b0e41891ec51725de0405f3fc2",
+      "size": 9875
     },
     {
       "path": "bin/session-prefix-migration.mjs",
@@ -59,8 +64,8 @@
     },
     {
       "path": "package.json",
-      "sha256": "a22736aea592668c4833876b6c5b6f5756ee1ec2a2a588abfbfeb04eb75f24ad",
-      "size": 1126
+      "sha256": "db999a00adbe3e8d894aa41082b59f456aef2c29718d7dcd14def319c2c78b09",
+      "size": 1030
     },
     {
       "path": "patches/dsh-better-sidebar@0.17.1.patch",
@@ -69,8 +74,8 @@
     },
     {
       "path": "pnpm-lock.yaml",
-      "sha256": "e6814d668f999856080c76c0524e34e08918fde37f09f52bafadcaea6e44c40e",
-      "size": 54856
+      "sha256": "5dab05b821c1fc14703dcb276d61774497a5fcfd0c8b5a28c090d968313f594d",
+      "size": 54625
     },
     {
       "path": "pnpm-workspace.yaml",
@@ -129,18 +134,18 @@
     },
     {
       "path": "tavern-plugin/lib/application-updater.js",
-      "sha256": "5bfa7625015ab650470cfcf3ded044beaad049c69f1c311b5b32c997c1e74d1d",
-      "size": 17564
+      "sha256": "a322fb1eb78ae5e1804e4043259717ef221d82d364371999a825fcefddc7856c",
+      "size": 20336
     },
     {
       "path": "tavern-plugin/lib/background-agent-runner.js",
-      "sha256": "19d22f733301113219a31efe5883dc7344badd17054eb3c4b3485ef9a68c03ab",
-      "size": 19531
+      "sha256": "bd1cf86acdc78187197ebccb20125d816d2970f41d58664e715520812f7363b4",
+      "size": 19865
     },
     {
       "path": "tavern-plugin/lib/client.js",
-      "sha256": "49975e4efa145502e894c31b41aac8a290f0d7fa1565b12c3e512e4e9a72ed25",
-      "size": 436877
+      "sha256": "24115ff292cc9398498c3952e462e1b67739137f0a12865b42ec3a6aa4a6cf6f",
+      "size": 437573
     },
     {
       "path": "tavern-plugin/lib/cordis-inspect.js",
@@ -219,8 +224,8 @@
     },
     {
       "path": "tavern-plugin/lib/domain/context-planner.js",
-      "sha256": "2138aed8c0f317ffe5b300351704a3dab2104ad6fc3eee50f1c96421ced01ece",
-      "size": 15100
+      "sha256": "980b0a241b1a85c06217c78ae2959a12cb99057f16e05512e78f943a88472737",
+      "size": 15520
     },
     {
       "path": "tavern-plugin/lib/domain/conversation-text-export.js",
@@ -249,8 +254,8 @@
     },
     {
       "path": "tavern-plugin/lib/domain/foreground-frame-session-adapter.js",
-      "sha256": "9450f20a83853588d47ca5f5c0a34dbbe4e853c44d1b0d7c78e864ea71d39e76",
-      "size": 2231
+      "sha256": "88c7bcc4ff3072a5547172459f8cced59b93eda25408009da41fd671acbb29ef",
+      "size": 3397
     },
     {
       "path": "tavern-plugin/lib/domain/foreground-handoff.js",
@@ -274,8 +279,13 @@
     },
     {
       "path": "tavern-plugin/lib/domain/mvu-background-settlement.js",
-      "sha256": "911ed5725e8e12497be37b6f6d9e5ffd75a2a8d5c5c3d5ed7a09fb85d58d05dd",
-      "size": 16590
+      "sha256": "b8d45840076daedf3524d7e01ff5db17a5b997f8d8721c5165f2bab653243098",
+      "size": 21919
+    },
+    {
+      "path": "tavern-plugin/lib/domain/mvu-diagnostics.js",
+      "sha256": "6d1950984b146cb00a064ce8dbb6619c3caf19ce5d6f3571ffa305e99d680016",
+      "size": 8430
     },
     {
       "path": "tavern-plugin/lib/domain/official-mvu-assets.js",
@@ -404,18 +414,18 @@
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-helper-context.js",
-      "sha256": "725b09242087da6fd781949949ca63a4de0e28bf06087dd69eff1eb81d984286",
-      "size": 6990
+      "sha256": "a360a98a5254b5d672b0ea1b21297e623af007becb9ce93ee7f64e334e0eec11",
+      "size": 7552
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-helper-event-gate.js",
-      "sha256": "c766e49bf73fb86db31b1536635fd7de6c59dc52749bbea0cc6c4b2352ed1709",
-      "size": 3755
+      "sha256": "22f94f952aae892896dc9b1f1d9c1e2aa09e6b84671981dab302255dff8ed5ac",
+      "size": 4160
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-helper-scripts.js",
-      "sha256": "940e95eec5fe2e906664c875b681f591ea505406c52b01edf35c231e3e92f731",
-      "size": 1731
+      "sha256": "a1d71590dc385ed749cf275c4f4b9a8f9045db19d2534fc86de7bdcb4204b9ad",
+      "size": 1738
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-helper-variable-macros.js",
@@ -444,8 +454,8 @@
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-remote-assets.js",
-      "sha256": "1085e403621129ab3afa177e6059911f4335ccf123a35b34e5a488d95cd798d2",
-      "size": 11802
+      "sha256": "54b568ef8d8e2a38c293fb5b9209364b7049dba92e461dce55db2c7c61d71650",
+      "size": 12129
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-retry-limiter.js",
@@ -454,13 +464,13 @@
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-script-host-adapter.js",
-      "sha256": "465623df8c7710177e4b5a75636a3bb364a9648f80f59b4bcb68533d55342433",
-      "size": 12751
+      "sha256": "f7c8c347cfbaa1f2be98eccef646f03f95df99a1f945e3045d1d153dc9c3bd12",
+      "size": 15856
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-settings.js",
-      "sha256": "03ec945f29b2a477b392e57e066762e026384ba8a07333328c49b4827ec9754c",
-      "size": 3384
+      "sha256": "b29694aa972df271746f707aabcb9c8a41dc3f220f92ba05b808f71d7ab0f57b",
+      "size": 3500
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-skills.js",
@@ -471,11 +481,6 @@
       "path": "tavern-plugin/lib/domain/tavern-static-resource-cache.js",
       "sha256": "c096cb0f42bd8595816143924b80f9800265f8fe7432c67322c760f4ca65348a",
       "size": 13432
-    },
-    {
-      "path": "tavern-plugin/lib/domain/tavern-style-environment.js",
-      "sha256": "c2696fd80e03dd04fda50edf4c5cc869c567415f62620534f51d37143f89b544",
-      "size": 1078
     },
     {
       "path": "tavern-plugin/lib/domain/tavern-swipe-regeneration.js",
@@ -519,8 +524,8 @@
     },
     {
       "path": "tavern-plugin/lib/index.js",
-      "sha256": "a15389a972ba7152a8d03c52245cb218384a632dcd3385cf0705434850cb7490",
-      "size": 212211
+      "sha256": "5b9522f5053d8cca799e265f0352e1f8789a17ef450fc5e4540a969a82ba9752",
+      "size": 213580
     },
     {
       "path": "tavern-plugin/lib/profile-data-store.js",

--- a/tavern-plugin/lib/client.js
+++ b/tavern-plugin/lib/client.js
@@ -60,7 +60,7 @@ window.__ModuleLoader__.load({
 .dsh-tavern-mvu-retry { justify-self: start; border: 1px solid var(--dsw-alias-border-l2); border-radius: 7px; padding: 4px 9px; background: transparent; color: var(--dsw-alias-label-primary); cursor: pointer; }
 .dsh-tavern-mvu-retry:disabled { cursor: wait; opacity: .58; }
 .dsh-tavern-message-frame-slot { display: block; width: 100%; min-height: 48px; overflow: hidden; }
-.dsh-tavern-message-frame { display: block; width: 100%; min-height: 48px; border: 0; background: transparent; overflow: hidden; }
+.dsh-tavern-message-frame { display: block; width: 100%; min-height: 48px; border: 0; background: transparent; overflow: hidden; pointer-events: none; }
 .dsh-tavern-status-runtime { width: 100%; min-width: 0; margin: 0 0 10px; overflow: hidden; border: 1px solid var(--dsw-alias-border-l2); border-radius: 12px; background: var(--dsw-alias-bg-base); }
 .dsh-tavern-user-row { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
 .dsh-tavern-user-stack { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; min-width: 0; max-width: min(525px, 82%); }


### PR DESCRIPTION
## 现象

在移动端浏览器（手机经 SSL/SSH 隧道访问 CLI 部署的 `localhost` 地址，命中 `dsh-web-mobile` 的窄屏分支）打开一个会话后：

- 左侧栏可以正常拖动、打开/关闭；
- 中间对话区（正文区域）无法纵向滚动；
- 进一步测试发现：**屏幕最左边、最右边的留白区域可以拖动，只有中间正文区域拖不动**。

桌面端不受影响。

## 原因

先排查dsh-tavern `dsh-web-mobile` 的全局 `touchmove` 手势逻辑。排除它导致的可能，因为那种拦截是全局性的，要么整页都不能滚，不会只卡中间。

真正原因在 dsh-tavern 自己的正文渲染层：每条 AI 回复都被渲染进一个
`<iframe class="dsh-tavern-message-frame">`：
// tavern-plugin/lib/client.js — TavernMessageFrame
React.createElement("iframe", {
  className: "dsh-tavern-message-frame",
  srcDoc: document.html,
  ...
})

.dsh-tavern-message-frame {
  display: block;
  width: 100%;
  min-height: 48px;
  border: 0;
  background: transparent;
  overflow: hidden;
}

iframe 的高度由内容高度测量后动态设置（`dsh-tavern-frame-height` 上报），
所以每条回复的 iframe 恰好贴合其内容，**内部没有可滚动的内容**。

但 iframe 是独立文档：手机在 iframe 上做纵向拖动手势时，触摸事件被 iframe
自身文档消费，而它内部 `overflow: hidden` 且高度已贴合内容，没有东西可滚，
于是这次拖动既不滚动 iframe、也不回传给外层滚动容器，表现为"中间正文拖不动"。
左右边缘是外层滚动容器的留白，没有 iframe 覆盖，所以能滚。

## 做了什么来修复

给正文 iframe 加上 `pointer-events: none`，让触摸事件直接穿过 iframe
落到外层滚动容器，恢复中间正文区的原生纵向滚动：
 .dsh-tavern-message-frame {
   display: block;
   width: 100%;
   min-height: 48px;
   border: 0;
   background: transparent;
   overflow: hidden;
   **pointer-events: none;**
}

改动只在 dsh-tavern 自己的 `tavern-plugin/lib/client.js`，不涉及
`dsh-web-mobile` 或任何其它依赖。

## 这次修复的影响

### 正面

- 移动端中间对话区恢复正常的纵向滚动；
- 左右边缘、侧栏开/关与列表滚动均保持原行为；
- 底部输入框、候选项、侧栏里的酒馆状态/MVU 面板都不在正文 iframe 内，
  不受影响，点击正常。

### 代价 / 副作用

`pointer-events: none` 会使 **iframe 内部的全部交互失效**，包括正文里若
渲染出的可点击内容（链接、按钮、表单、HTML 面板里的交互控件）。

对当前核心玩法（读正文、选候选项、自由输入、右侧查看状态）没有影响，
但如果某张人物卡的正则美化把状态渲染成了正文内可点击的 HTML 面板，
这些控件会点不了。

### 建议：限定到移动端

**上面是最小改动。若希望桌面端完全不受影响（保留正文内点击交互），
建议把该规则限定到移动触屏分支：**
@media (max-width: 1023px) and (pointer: coarse) {
  .dsh-tavern-message-frame {
    pointer-events: none;
  }
}

### 长期方向（如需保留 iframe 内交互）

`pointer-events: none` 是"让触摸穿透"的简单方案。若未来需要正文内的
点击交互（例如点击正文里的链接/按钮），需要更精细的处理，例如：

- 仅在触摸滚动进行中临时禁用 iframe 命中，滚动结束再恢复；
- 或给 iframe 外层滚动容器增加专门的触摸手势转发。

这两种需要改 `TavernMessageFrame` 的渲染/事件逻辑，可作为后续优化。
本次 PR 先解决"移动端正文无法滚动"这一阻断性问题。