### PR TITLE
fix: adapt foreground worldbook template callback arguments

### DIFF
--- a/tavern-plugin/lib/index.js
+++ b/tavern-plugin/lib/index.js
@@ -2092,7 +2092,7 @@ export async function apply(ctx) {
       return renderCardText(text, { name: chat.cardName }, chat.macroState)
     },
     projectReply: projectRuntimeReply,
-    projectWorldBookTemplates: nativeWorldBookTemplateContext,
+    projectWorldBookTemplates: input => nativeWorldBookTemplateContext(input.chat, input.card),
     projectScriptPromptWorldbook: async function ({ chat, card, turn }) {
       const text = scriptPromptScanText(chat)
       if (!text.trim()) return null


### PR DESCRIPTION
前台每轮准备正文时，动态世界书模板投影回调的参数约定与接收函数不一致，导致读取失败并跳过模板上下文。此 PR 仅修改 `tavern-plugin/lib/index.js` 中的一行。

`turn-orchestration.js` 通过 `projectWorldBookTemplates({ chat, card, turn, userText })` 传入一个对象，但直接接入的 `nativeWorldBookTemplateContext(chat, card)` 使用两个位置参数。因此函数内的 `chat.cardPath` 和第二个参数 `card` 均为 `undefined`，世界书读取在路径校验阶段失败，被捕获后返回 `worldbook-read-failed` 和空上下文；此时尚未执行 EJS。

将前台回调改为 `input => nativeWorldBookTemplateContext(input.chat, input.card)`，使其收到实际的 chat 和 card。
